### PR TITLE
Fix Fraction naming error

### DIFF
--- a/src/pch.h
+++ b/src/pch.h
@@ -299,7 +299,7 @@ struct Fraction
 
 	Fraction<T> Simplify() {
 		T t = gcd(Num, Den);
-		return Fraction{ a / t, b / t };
+		return Fraction{ Num / t, Den / t };
 	}
 
 	operator double() {


### PR DESCRIPTION
I was building raindrop myself on Arch Linux and came across this error. Thought I'd send the quick fix your way!